### PR TITLE
Release 0.999

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "html5lib" %}
-{% set version = "0.999999999" %}
-{% set sha256 = "ee747c0ffd3028d2722061936b5c65ee4fe13c8e4613519b4447123fc4546298" %}
+{% set version = "0.999" %}
+{% set sha256 = "c3887f7e2875d7666107fa8bee761ff95b9391acdcc7cd1b5fd57a23b5fbc49e" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Seems like some things like this version for some reason. So figured we can go ahead package it. That way the package comes from `conda-forge` instead of `defaults`, which should give us more control should we need it.

Note: This is not targeted against `master`. Thus it won't affect the version in there. This release will be managed via a different branch.