### PR TITLE
recipe for v0.9999999

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "html5lib" %}
-{% set version = "0.999999999" %}
-{% set sha256 = "ee747c0ffd3028d2722061936b5c65ee4fe13c8e4613519b4447123fc4546298" %}
+{% set version = "0.9999999" %}
+{% set sha256 = "2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
I am interested in getting an updated tensorflow 1.2 recipe (see https://github.com/conda-forge/tensorflow-feedstock/issues/35). Unfortunately, there is a new feature of tensorboard that make tensorflow now require an older build of html5lib.

I am not sure how to open a PR onto a non-existent branch, so I opened this against master, but if a maintainer could create a v0.9999999 branch, I could close this PR and open it against that branch. 